### PR TITLE
Show /etc/motd or /etc/update-motd.d/, not both

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -146,8 +146,7 @@ function _get_remote_command(){
     local commands_opt=""
     [[ -z "${COMMANDS[@]}" ]] || commands_opt="-c \"${COMMANDS[@]}\""
     $CAT <<EOF
-[[ -e /etc/update-motd.d ]] && command -v run-parts &> /dev/null && run-parts /etc/update-motd.d/
-[[ -e /etc/motd ]] && $CAT /etc/motd;
+[[ -e /etc/motd ]] && $CAT /etc/motd || { [[ -e /etc/update-motd.d ]] && command -v run-parts &> /dev/null && run-parts /etc/update-motd.d/; }
 [[ -d "$GNUBIN" ]] && PATH="$GNUBIN:\$PATH";
 for tmp_dir in ${BASE_DIRS[@]}; do [[ -w "\$tmp_dir" ]] && { base_dir="\$tmp_dir"; break; } done;
 [[ -z "\$base_dir" ]] && { echo >&2 "Could not find writable temp directory on the remote host. Aborting."; exit $NO_WRITABLE_DIRECTORY; };


### PR DESCRIPTION
ref: https://github.com/Russell91/sshrc/pull/83

## before (amazon linux)

```
$ kyrat remotehost
/etc/update-motd.d//30-banner:


       __|  __|_  )
       _|  (     /   Amazon Linux AMI
      ___|\___|___|

https://aws.amazon.com/amazon-linux-ami/2018.03-release-notes/

       __|  __|_  )
       _|  (     /   Amazon Linux AMI
      ___|\___|___|

https://aws.amazon.com/amazon-linux-ami/2018.03-release-notes/
```

motd shows twice 😫
And slow (In amazon linux, `/etc/update-motd.d/70-available-updates`checks package updates) 

## after (amazon linux)

```
$ kyrat remotehost
Last login: Sun May 12 14:38:57 2019 from ip-0-0-0-0.ap-northeast-1.compute.internal

       __|  __|_  )
       _|  (     /   Amazon Linux AMI
      ___|\___|___|

https://aws.amazon.com/amazon-linux-ami/2018.03-release-notes/
```

🤗